### PR TITLE
Include Datastore support for comments

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -26,6 +26,11 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -63,8 +63,10 @@ public class DataServlet extends HttpServlet {
 
   private Entity createCommentEntity(String commentText) {
     Entity commentEntity = new Entity("Comment");
-    
+    long timestamp = System.currentTimeMillis();
+
     commentEntity.setProperty("content", commentText);
+    commentEntity.setProperty("timestamp", timestamp);
 
     return commentEntity;
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -63,8 +63,7 @@ public class DataServlet extends HttpServlet {
 
   private Entity createCommentEntity(String commentText) {
     Entity commentEntity = new Entity("Comment");
-
-    commentEntity.setProperty("timestamp", Instant.now());
+    
     commentEntity.setProperty("content", commentText);
 
     return commentEntity;

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -15,9 +15,7 @@
 package com.google.sps.servlets;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -27,6 +25,9 @@ import javax.servlet.http.HttpServletResponse;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.gson.Gson;
 
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
@@ -34,16 +35,17 @@ import com.google.gson.Gson;
 public class DataServlet extends HttpServlet {
   private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-  private ArrayList<String> comments = new ArrayList<>(
-    Arrays.asList(
-      "Hello world",
-      "It's me",
-      "It's José"
-    )
-  );
-
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
+    PreparedQuery results = datastore.prepare(query);
+
+    ArrayList<String> comments = new ArrayList<>();
+    for (Entity entity : results.asIterable()) {
+      String comment = (String) entity.getProperty("content");
+      comments.add(comment);
+    }
+
     Gson gson = new Gson();
     String json = gson.toJson(comments);
     

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -24,11 +24,16 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
 import com.google.gson.Gson;
 
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
+  private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
   private ArrayList<String> comments = new ArrayList<>(
     Arrays.asList(
       "Hello world",
@@ -48,9 +53,11 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String comment = request.getParameter("comment");
-    comments.add(comment);
+    String commentText = request.getParameter("comment");
+    Entity commentEntity = createCommentEntity(commentText);
 
+    datastore.put(commentEntity);
+    
     response.sendRedirect("/");
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -15,6 +15,7 @@
 package com.google.sps.servlets;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -51,5 +52,14 @@ public class DataServlet extends HttpServlet {
     comments.add(comment);
 
     response.sendRedirect("/");
+  }
+
+  private Entity createCommentEntity(String commentText) {
+    Entity commentEntity = new Entity("Comment");
+
+    commentEntity.setProperty("timestamp", Instant.now());
+    commentEntity.setProperty("content", commentText);
+
+    return commentEntity;
   }
 }


### PR DESCRIPTION
These changes allow comments to be persisted to and fetched from Datastore, instead of an in-memory, hard-written, ArrayList.

Demo: https://datastore-comments-dot-josedramirez-step-2020.appspot.com

Should be merged to master only after #5.