### PR TITLE
Optional attendees

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -32,7 +32,24 @@ public final class FindMeetingQuery {
    * @return A collection of available times.
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    List<TimeRange> unavailableTimeRanges = getUnavailableTimes(events, request.getAttendees());
+    Collection<TimeRange> suggestedTimeRanges = findTimeForMeetingRequest(events, request, true);
+
+    if (suggestedTimeRanges.size() == 0 && request.getAttendees().size() != 0) {
+      suggestedTimeRanges = findTimeForMeetingRequest(events, request, false);
+    }
+
+    return suggestedTimeRanges;
+  }
+
+  public Collection<TimeRange> findTimeForMeetingRequest(Collection<Event> events, MeetingRequest request, 
+      boolean includeOptionalAttendees) {
+    List<String> attendees = new ArrayList<>(request.getAttendees());
+
+    if (includeOptionalAttendees) {
+      attendees.addAll(request.getOptionalAttendees());
+    }
+
+    List<TimeRange> unavailableTimeRanges = getUnavailableTimes(events, attendees);
     List<TimeRange> suggestedTimeRanges = findAvailableTimeRanges(unavailableTimeRanges, request.getDuration());
 
     return suggestedTimeRanges;

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,6 +34,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -43,6 +44,7 @@ public final class FindMeetingQueryTest {
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
 
+  private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;


### PR DESCRIPTION
These changes include optional attendee functionality for event requests. If an time is found when optional attendees can attend, it will be returned. Otherwise, only required attendees are considered.

There is no demo for this PR, as the changes are not visual. It can also be merged in no particular order.